### PR TITLE
Mb/53 - Add ground transparency slider to basemap gallery widget

### DIFF
--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -344,8 +344,6 @@ export const configDev = {
 		// webScene: 'dd370d1e2c194f4491078b579379f1d1',
 		// webScene: 'dd370d1e2c194f4491078b579379f1d1',
 		// webScene: '6e43620d338a418481c9702fe2a97f26',
-
-		// Below is the v1.2 (old) web scene
 		// webScene: 'c6c5e203c3ab44058353f151ad967b59',
 
 		webScene: 'c28d269394414b0cb55b2e3308816bb3', // 15

--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -345,9 +345,11 @@ export const configDev = {
 		// webScene: 'dd370d1e2c194f4491078b579379f1d1',
 		// webScene: '6e43620d338a418481c9702fe2a97f26',
 
-		// Below is the correct scene, I don't have access currently
-		// webScene: 'c28d269394414b0cb55b2e3308816bb3', // 15
-		webScene: 'c6c5e203c3ab44058353f151ad967b59',
+		// Below is the v1.2 (old) web scene
+		// webScene: 'c6c5e203c3ab44058353f151ad967b59',
+
+		webScene: 'c28d269394414b0cb55b2e3308816bb3', // 15
+
 		elevationUrl: '//elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
 	},
 	wells3D: {

--- a/src/config.dev.ts
+++ b/src/config.dev.ts
@@ -344,7 +344,10 @@ export const configDev = {
 		// webScene: 'dd370d1e2c194f4491078b579379f1d1',
 		// webScene: 'dd370d1e2c194f4491078b579379f1d1',
 		// webScene: '6e43620d338a418481c9702fe2a97f26',
-		webScene: 'c28d269394414b0cb55b2e3308816bb3', // 15
+
+		// Below is the correct scene, I don't have access currently
+		// webScene: 'c28d269394414b0cb55b2e3308816bb3', // 15
+		webScene: 'c6c5e203c3ab44058353f151ad967b59',
 		elevationUrl: '//elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
 	},
 	wells3D: {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,4 +1,5 @@
 @import '~@arcgis/core/assets/esri/themes/light/main.css';
+
 :root {
   --blue: #2196F3;
   --gray: #efefef;
@@ -6,7 +7,8 @@
   --orange: #f97d1a
 }
 
-html, body {
+html,
+body {
   height: 100%;
   width: 100%;
   margin: 0;
@@ -270,6 +272,7 @@ input:checked+.slider:before {
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }
@@ -324,4 +327,8 @@ input:checked+.slider:before {
 
 .esri-feature-table__content {
   height: 400px;
+}
+
+.esri-slider {
+  min-width: 300px;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -338,13 +338,21 @@ input:checked+.slider:before {
   margin-right: auto;
 }
 
+.esri-slider__tick.sliderQuarterTicks {
+  height: 7px;
+}
+
+.esri-slider__tick.sliderSmallTicks {
+  height: 3px;
+}
+
 #basemapGalleryDiv {
   min-width: 280px;
-  max-height: 440px;
+  max-height: 400px;
 }
 
 #basemap-gallery-footer-container {
-  height: auto !important;
+  height: auto;
   border-top: 1px #a9a9a9 solid;
   margin-top: 0px;
   display: flex;
@@ -356,4 +364,5 @@ input:checked+.slider:before {
 
 #basemap-gallery-footer {
   height: fit-content;
+  margin-bottom: 10px;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -330,5 +330,30 @@ input:checked+.slider:before {
 }
 
 .esri-slider {
-  min-width: 300px;
+  min-width: 240px;
+}
+
+#opacLabel {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+#basemapGalleryDiv {
+  min-width: 280px;
+  max-height: 440px;
+}
+
+#basemap-gallery-footer-container {
+  height: auto !important;
+  border-top: 1px #a9a9a9 solid;
+  margin-top: 0px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 0px 30px 30px 30px;
+}
+
+#basemap-gallery-footer {
+  height: fit-content;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -336,14 +336,31 @@ input:checked+.slider:before {
 #opacLabel {
   margin-left: auto;
   margin-right: auto;
+  font-size: 12px;
 }
 
 .esri-slider__tick.sliderQuarterTicks {
   height: 7px;
 }
 
+.esri-slider__tick.sliderQuarterTicks:hover {
+  cursor: pointer;
+}
+
+.esri-slider__tick-label.sliderQuarterLabels {
+  font-size: 9px;
+}
+
+.esri-slider__tick-label.sliderQuarterLabels:hover {
+  cursor: pointer;
+}
+
 .esri-slider__tick.sliderSmallTicks {
   height: 3px;
+}
+
+.esri-slider__tick.sliderSmallTicks:hover {
+  cursor: pointer;
 }
 
 #basemapGalleryDiv {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -7,33 +7,31 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <meta name="mobile-web-app-capable" content="yes">
   <title>Central Basin Map</title>
-  <% if (htmlWebpackPlugin.options.mode === 'production') { %>
-  <script>
-    // Check that service workers are registered
-    if ('serviceWorker' in navigator) {
-      // Use the window load event to keep the page load performant
-      window.addEventListener("load", function () {
-        navigator.serviceWorker.register("./service-worker.js")
-          .catch(() => {
-            console.log("Service Worker not loaded");
-          });
-      });
-    }
-  </script>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src=https://www.googletagmanager.com/gtag/js?id=UA-32633028-1></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
-    gtag('config', 'UA-32633028-1');
-  </script>
-  <% } %>
-  <% 
-  
-  %>
+  <% if (htmlWebpackPlugin.options.mode==='production' ) { %>
+    <script>
+      // Check that service workers are registered
+      if ('serviceWorker' in navigator) {
+        // Use the window load event to keep the page load performant
+        window.addEventListener("load", function () {
+          navigator.serviceWorker.register("./service-worker.js")
+            .catch(() => {
+              console.log("Service Worker not loaded");
+            });
+        });
+      }
+    </script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=https://www.googletagmanager.com/gtag/js?id=UA-32633028-1></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'UA-32633028-1');
+    </script>
+    <% } %>
+      <% %>
 </head>
 
 <body>
@@ -61,14 +59,26 @@
 
     <div id="layerLegendDiv" class="esri-widget">
       <div id="llTabs" class="calcite-tabs" layout="inline" position="above">
-        <button id="layers-button" class="calcite-tab wells2d esri-widget--button active-button" onclick="toggleLLTab()">Layers</button>
-        <button id="legend-button" class="calcite-tab wells2d esri-widget--button" onclick="toggleLLTab()">Legend</button>
+        <button id="layers-button" class="calcite-tab wells2d esri-widget--button active-button"
+          onclick="toggleLLTab()">Layers</button>
+        <button id="legend-button" class="calcite-tab wells2d esri-widget--button"
+          onclick="toggleLLTab()">Legend</button>
       </div>
       <div id="llDivs" class="tableDivs">
         <div id="layers-content" class="tab-content active-div esri-widget active-content"></div>
         <div id="legend-content" class="tab-content active-div esri-widget"></div>
       </div>
-    </div> 
+    </div>
+
+    <div id="basemapDiv" class="esri-widget">
+      <div id="basemapGalleryDiv" class="esri-widget"></div>
+      <div id="basemap-gallery-footer-container">
+        <h4 id="opacLabel">Ground transparency</h4>
+        <div id="basemap-gallery-footer">
+          <div id="opacitySliderDiv" class="esri-widget"></div>
+        </div>
+      </div>
+    </div>
 
     <div id="featureSearchDiv" class="esri-widget">
       <input type="text" id="featureSearch" class="esri-input esri-feature-form__input"

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -27,6 +27,7 @@ import Graphic from '@arcgis/core/Graphic';
 
 let appContainer: HTMLElement | null;
 let tableContainer: HTMLElement | null;
+let basemapDiv = document.getElementById("basemapGalleryDiv")?.parentElement;
 
 // Get reference to div elements
 let labelText: HTMLElement | null;
@@ -40,6 +41,7 @@ export const initWidgets = (view: SceneView) => {
 
 	const basemapGallery = new BasemapGallery({
 		view: view,
+		container: 'basemapGalleryDiv',
 		// @ts-ignore
 		source: {
 			portal: info.portalUrl,
@@ -59,18 +61,25 @@ export const initWidgets = (view: SceneView) => {
 	});
 
 	const opacSlider = new Slider({
-		container: document.createElement("div"),
+		container: 'opacitySliderDiv',
+		label: 'Ground transparency',
 		min: 0,
 		max: 1,
+		layout: "horizontal-reversed",
 		values: [1],
-		precision: 2,
-		steps: 0.1,
+		steps: 0.01,
 		snapOnClickEnabled: true,
 		visibleElements: {
-			labels: true,
-			rangeLabels: true
+			labels: false,
+			rangeLabels: false
 		}
 	})
+
+	opacSlider.tickConfigs = [{
+		mode: "percent",
+		values: [0, 25, 50, 75, 100],
+		labelsVisible: false
+	}];
 
 	// @ts-ignore
 	opacSlider.on(['thumb-change', 'thumb-drag'], function (event) {
@@ -136,21 +145,21 @@ export const initWidgets = (view: SceneView) => {
 
 	const basemapExpand = new Expand({
 		view,
-		content: basemapGallery,
+		content: basemapDiv,
 		expandIconClass: 'esri-icon-basemap',
 		autoCollapse: true,
 		group: 'top-left',
 		expandTooltip: 'Basemaps',
 	});
 
-	const opacExpand = new Expand({
-		view,
-		content: opacSlider.container,
-		expandIconClass: 'esri-icon-feature-layer',
-		autoCollapse: true,
-		group: 'top-left',
-		expandTooltip: 'Basemap Opacity'
-	})
+	// const opacExpand = new Expand({
+	// 	view,
+	// 	content: opacSlider.container,
+	// 	expandIconClass: 'esri-icon-feature-layer',
+	// 	autoCollapse: true,
+	// 	group: 'top-left',
+	// 	expandTooltip: 'Basemap Opacity'
+	// })
 
 	const lineMeasurementExpand = new Expand({
 		view,
@@ -213,7 +222,7 @@ export const initWidgets = (view: SceneView) => {
 
 	view.ui.add(homeButton, 'top-left');
 	view.ui.add(basemapExpand, 'top-left');
-	view.ui.add(opacExpand, 'top-left');
+	// view.ui.add(opacExpand, 'top-left');
 
 	view.ui.add(lineMeasurementExpand, 'top-left');
 	view.ui.add(areaMeasurementExpand, 'top-left');

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -118,13 +118,8 @@ export const initWidgets = (view: SceneView) => {
 	}
 	];
 
-	// ToDo: Replace label text
-
-
-
 	// @ts-ignore
 	opacSlider.on(['thumb-change', 'thumb-drag'], function (event) {
-		console.log(event.value);
 		map.ground.opacity = event.value;
 	})
 
@@ -255,7 +250,6 @@ export const initWidgets = (view: SceneView) => {
 
 	view.ui.add(homeButton, 'top-left');
 	view.ui.add(basemapExpand, 'top-left');
-	// view.ui.add(opacExpand, 'top-left');
 
 	view.ui.add(lineMeasurementExpand, 'top-left');
 	view.ui.add(areaMeasurementExpand, 'top-left');

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -106,6 +106,24 @@ export const initWidgets = (view: SceneView) => {
 						break;
 				}
 			}
+
+			// @ts-ignore
+			labelElement.onclick = function () {
+				// @ts-ignore
+				const newValue = labelElement["data-value"];
+				opacSlider.values = [newValue];
+				// @ts-ignore
+				map.ground.opacity = [newValue];
+			};
+
+			// @ts-ignore
+			tickElement.onclick = function () {
+				// @ts-ignore
+				const newValue = tickElement["data-value"];
+				opacSlider.values = [newValue];
+				// @ts-ignore
+				map.ground.opacity = [newValue];
+			};
 		}
 	}, {
 		mode: "percent",
@@ -114,6 +132,15 @@ export const initWidgets = (view: SceneView) => {
 		tickCreatedFunction: function (initialValue, tickElement, labelElement) {
 			tickElement.classList.add("sliderSmallTicks");
 			labelElement?.classList.add("sliderSmallLabels");
+
+			// @ts-ignore
+			tickElement.onclick = function () {
+				// @ts-ignore
+				const newValue = tickElement["data-value"];
+				opacSlider.values = [newValue];
+				// @ts-ignore
+				map.ground.opacity = [newValue];
+			};
 		}
 	}
 	];

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -78,8 +78,49 @@ export const initWidgets = (view: SceneView) => {
 	opacSlider.tickConfigs = [{
 		mode: "percent",
 		values: [0, 25, 50, 75, 100],
-		labelsVisible: false
-	}];
+		labelsVisible: true,
+		tickCreatedFunction: function (initialValue, tickElement, labelElement) {
+			tickElement.classList.add("sliderQuarterTicks");
+			labelElement?.classList.add("sliderQuarterLabels");
+
+			let sliderLabels = document.getElementsByClassName("sliderQuarterLabels");
+			for (let i = 0; i < sliderLabels.length; i++) {
+				switch (sliderLabels[i].innerHTML) {
+					case "1":
+						sliderLabels[i].innerHTML = "0";
+						break;
+					case "0.75":
+						sliderLabels[i].innerHTML = "25";
+						break;
+					case "0.5":
+						sliderLabels[i].innerHTML = "50";
+						break;
+					case "0.25":
+						sliderLabels[i].innerHTML = "75";
+						break;
+					case "0":
+						sliderLabels[i].innerHTML = "100";
+						break;
+
+					default:
+						break;
+				}
+			}
+		}
+	}, {
+		mode: "percent",
+		values: [5, 10, 15, 20, 30, 35, 40, 45, 55, 60, 65, 70, 80, 85, 90, 95],
+		labelsVisible: false,
+		tickCreatedFunction: function (initialValue, tickElement, labelElement) {
+			tickElement.classList.add("sliderSmallTicks");
+			labelElement?.classList.add("sliderSmallLabels");
+		}
+	}
+	];
+
+	// ToDo: Replace label text
+
+
 
 	// @ts-ignore
 	opacSlider.on(['thumb-change', 'thumb-drag'], function (event) {
@@ -145,21 +186,13 @@ export const initWidgets = (view: SceneView) => {
 
 	const basemapExpand = new Expand({
 		view,
+		// @ts-ignore
 		content: basemapDiv,
 		expandIconClass: 'esri-icon-basemap',
 		autoCollapse: true,
 		group: 'top-left',
 		expandTooltip: 'Basemaps',
 	});
-
-	// const opacExpand = new Expand({
-	// 	view,
-	// 	content: opacSlider.container,
-	// 	expandIconClass: 'esri-icon-feature-layer',
-	// 	autoCollapse: true,
-	// 	group: 'top-left',
-	// 	expandTooltip: 'Basemap Opacity'
-	// })
 
 	const lineMeasurementExpand = new Expand({
 		view,

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -1,4 +1,4 @@
-import { mapProperties } from './data/app';
+import { map, mapProperties } from './data/app';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
@@ -18,6 +18,7 @@ import BasemapGallery from '@arcgis/core/widgets/BasemapGallery';
 import Search from '@arcgis/core/widgets/Search';
 import WebScene from '@arcgis/core/WebScene';
 import Basemap from '@arcgis/core/Basemap';
+import Slider from "@arcgis/core/widgets/Slider";
 import FeatureTable from '@arcgis/core/widgets/FeatureTable';
 import { info } from './data/app';
 import { watch } from '@arcgis/core/core/watchUtils';
@@ -56,6 +57,26 @@ export const initWidgets = (view: SceneView) => {
 			},
 		},
 	});
+
+	const opacSlider = new Slider({
+		container: document.createElement("div"),
+		min: 0,
+		max: 1,
+		values: [1],
+		precision: 2,
+		steps: 0.1,
+		snapOnClickEnabled: true,
+		visibleElements: {
+			labels: true,
+			rangeLabels: true
+		}
+	})
+
+	// @ts-ignore
+	opacSlider.on(['thumb-change', 'thumb-drag'], function (event) {
+		console.log(event.value);
+		map.ground.opacity = event.value;
+	})
 
 	const lineMeasurement = new DirectLineMeasurement3D({
 		view: view,
@@ -122,6 +143,15 @@ export const initWidgets = (view: SceneView) => {
 		expandTooltip: 'Basemaps',
 	});
 
+	const opacExpand = new Expand({
+		view,
+		content: opacSlider.container,
+		expandIconClass: 'esri-icon-feature-layer',
+		autoCollapse: true,
+		group: 'top-left',
+		expandTooltip: 'Basemap Opacity'
+	})
+
 	const lineMeasurementExpand = new Expand({
 		view,
 		content: lineMeasurement,
@@ -183,6 +213,7 @@ export const initWidgets = (view: SceneView) => {
 
 	view.ui.add(homeButton, 'top-left');
 	view.ui.add(basemapExpand, 'top-left');
+	view.ui.add(opacExpand, 'top-left');
 
 	view.ui.add(lineMeasurementExpand, 'top-left');
 	view.ui.add(areaMeasurementExpand, 'top-left');

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -66,7 +66,7 @@ export const initWidgets = (view: SceneView) => {
 		min: 0,
 		max: 1,
 		layout: "horizontal-reversed",
-		values: [1],
+		values: [map.ground.opacity],
 		steps: 0.01,
 		snapOnClickEnabled: true,
 		visibleElements: {

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -216,6 +216,10 @@ export const initWidgets = (view: SceneView) => {
 		expandTooltip: 'Basemaps',
 	});
 
+	basemapExpand.watch('expanded', () => {
+		opacSlider.values = [map.ground.opacity];
+	});
+
 	const lineMeasurementExpand = new Expand({
 		view,
 		content: lineMeasurement,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const ArcGISPlugin = require('@arcgis/webpack-plugin');
-const {CleanWebpackPlugin} = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -66,7 +66,7 @@ module.exports = function build(env, arg) {
     },
     optimization: {
       minimize: arg.mode === 'production',
-      splitChunks: {minChunks: Infinity, chunks: 'all'},
+      splitChunks: { minChunks: Infinity, chunks: 'all' },
       minimizer: [
         new TerserPlugin({
           parallel: true,
@@ -83,7 +83,7 @@ module.exports = function build(env, arg) {
       },
     },
     plugins: [
-      new CleanWebpackPlugin({cleanStaleWebpackAssets: false}),
+      new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
 
       new MiniCssExtractPlugin({
         filename: '[name].bundle.css',
@@ -102,6 +102,7 @@ module.exports = function build(env, arg) {
         chunksSortMode: 'none',
         inlineSource: '.(css)$',
         mode: arg.mode,
+        minify: false,
       }),
 
       new HtmlWebPackPlugin({


### PR DESCRIPTION
This PR resolves #53, adding the ability to adjust basemap/ground transparency which will allow users to view objects underground.

I imitated styling of the ground transparency slider in the Central Basin 3D Scene - v1.3 beta scene shown here:

![image](https://user-images.githubusercontent.com/94854808/200642778-e91a12d3-6acf-4fd9-8bbc-c1653b157a78.png)


Here is a demo showing the added functionality matching the above example scene:

[basemap-transparency.webm](https://user-images.githubusercontent.com/94854808/200663135-c36d438b-d616-407a-b633-430da1351328.webm)


